### PR TITLE
fix: Update Go to 1.26.2 to mitigate vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-trixie as build
+FROM golang:1.26.2-trixie as build
 WORKDIR /src
 COPY . /src
 RUN CGO_ENABLED=0 go build -o /cc-device-plugin


### PR DESCRIPTION
This change addresses a vulnerability found in the Go standard library in versions prior to 1.26.2.