### PR TITLE
feat: Configure Dependabot for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # 1. Go dependencies updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # 2. Docker image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # 3. GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      


### PR DESCRIPTION
Enable Dependabot version updates for the repository to automate dependency management.

This PR adds .github/dependabot.yml to perform weekly checks for:

- Go dependencies (gomod)
- Docker images
- GitHub Actions