### PR TITLE
Upgrade Go compiler to 1.26.4 to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-trixie as build
+FROM golang:1.26.4-trixie as build
 WORKDIR /src
 COPY . /src
 RUN CGO_ENABLED=0 go build -o /cc-device-plugin


### PR DESCRIPTION
Upgrade Go builder to 1.26.4 to fix GO_STDLIB vulns & trigger OS package updates (OpenSSL, glibc)