### PR TITLE
docs: document supportability metrics and GKE monitoring in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ spec:
 ```
 Inside this container, `/dev/tpmrm0` will be available.
 
+## Monitoring
+
+Applying the Prometheus monitoring manifest allows you to observe the device plugin status:
+
+```bash
+kubectl apply -f manifests/cc-device-plugin-pod-monitoring.yaml
+```
+
+You can view the metrics in the [Cloud Monitoring Metrics Explorer](https://console.cloud.google.com/monitoring/metrics-explorer) using PromQL, for example to see CPU usage:
+```promql
+rate(process_cpu_seconds_total[5m])
+```
+
 [dp]: https://kubernetes.io/docs/concepts/cluster-administration/device-plugins/
 [k8s]: https://kubernetes.io
 [tpm]: https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm


### PR DESCRIPTION
## Description
This PR adds a **Monitoring** section to the `README.md` to document how to observe the `cc-device-plugin` status.

Specifically, it documents:
- GKE PodMonitoring deployment using the provided manifest `manifests/cc-device-plugin-pod-monitoring.yaml`.
- How to query metrics using PromQL in the Cloud Monitoring Metrics Explorer (with a CPU usage metric example).