### PR TITLE
build(deps): bump golang from 1.26.5-trixie to 1.26.6-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-trixie as build
+FROM golang:1.26.6-trixie as build
 WORKDIR /src
 COPY . /src
 RUN CGO_ENABLED=0 go build -o /cc-device-plugin


### PR DESCRIPTION
Bump golang from 1.26.5-trixie to 1.26.6-trixie